### PR TITLE
fix: Unable to unmark when `revealed=true` after marking

### DIFF
--- a/src/composables/logic.ts
+++ b/src/composables/logic.ts
@@ -120,7 +120,8 @@ export class GamePlay {
     this.getSiblings(block)
       .forEach((s) => {
         if (!s.revealed) {
-          s.revealed = true
+          if (!s.flagged)
+            s.revealed = true
           this.expendZero(s)
         }
       })


### PR DESCRIPTION
### Issues:
[#10](https://github.com/antfu/vue-minesweeper/issues/10)

![CPT2203171606-537x488](https://user-images.githubusercontent.com/47295879/158764453-12715d6b-a44f-4265-9038-d978cd0391d0.gif)
