### PR TITLE
feat: addGameStatus:'ready'

### DIFF
--- a/src/composables/logic.ts
+++ b/src/composables/logic.ts
@@ -13,13 +13,13 @@ const directions = [
   [0, 1],
 ]
 
-type GameStatus = 'play' | 'won' | 'lost'
+type GameStatus = 'ready' | 'play' | 'won' | 'lost'
 
 interface GameState {
   board: BlockState[][]
   mineGenerated: boolean
   status: GameStatus
-  startMS: number
+  startMS?: number
   endMS?: number
 }
 
@@ -54,9 +54,8 @@ export class GamePlay {
     this.mines = mines
 
     this.state.value = {
-      startMS: +Date.now(),
       mineGenerated: false,
-      status: 'play',
+      status: 'ready',
       board: Array.from({ length: this.height }, (_, y) =>
         Array.from({ length: this.width },
           (_, x): BlockState => ({
@@ -137,6 +136,10 @@ export class GamePlay {
   }
 
   onClick(block: BlockState) {
+    if (this.state.value.status === 'ready') {
+      this.state.value.status = 'play'
+      this.state.value.startMS = +new Date()
+    }
     if (this.state.value.status !== 'play' || block.flagged)
       return
 

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,7 +5,7 @@ import { GamePlay } from '~/composables/logic'
 const play = new GamePlay(6, 6, 3)
 
 const now = $(useNow())
-const timerMS = $computed(() => Math.round(((play.state.value.endMS || +now) - play.state.value.startMS) / 1000))
+const timerMS = $computed(() => Math.round(((play.state.value.endMS ?? +now) - (play.state.value.startMS ?? +now)) / 1000))
 
 useStorage('vuesweeper-state', play.state)
 const state = $computed(() => play.board)


### PR DESCRIPTION
Using the 'ready' status as the initial state of the game, when clicking on the block, to 'play' status and start timing