### PR TITLE
fix: game state check logic

### DIFF
--- a/src/composables/logic.ts
+++ b/src/composables/logic.ts
@@ -176,15 +176,12 @@ export class GamePlay {
   }
 
   checkGameState() {
-    if (!this.state.value.mineGenerated)
+    if (!this.state.value.mineGenerated || this.state.value.status !== 'play')
       return
     const blocks = this.board.flat()
 
-    if (blocks.every(block => block.revealed || block.flagged || block.mine)) {
-      if (blocks.some(block => block.flagged && !block.mine))
-        this.onGameOver('lost')
-      else
-        this.onGameOver('won')
+    if (!blocks.some(block => !block.mine && !block.revealed)) {
+      this.onGameOver('won')
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Thanks for the fantastic project and I really enjoy the live show.

But as a senior minesweeper, I think there is something wrong with the game state check logic. The game become 'won' state if and only if all the block with no mine is revealed and the game become 'lost' state under tow circumstances: 1. reveal a block with mine by left click. 2. false flag with double click.

So the `checkGameState` function should not check the lost condition which they are all checked in other places, change the logic to only check win condition with `!blocks.some(block => !block.mine && !block.revealed)` which means all no mine block has been revealed is just fine here.

An example of false check is shown below:

<img width="454" alt="image" src="https://user-images.githubusercontent.com/8512426/159149193-b49a9e7b-b10d-4127-bf9a-7ef546e35014.png">

The false flag in the board should not make the game lost here since on mine block has been revealed by left click or double click.

And here is my [minesweeper profile](http://saolei.wang/Player/Index.asp?Id=2578)~